### PR TITLE
Nix package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  version = "0.28.1.240417";
+in
+pkgs.python3Packages.buildPythonPackage {
+  name = "opp_env";
+  src = ./.;
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  propagatedBuildInputs = with pkgs.python3Packages; [
+    pkgs.nix
+    pkgs.curl
+    pkgs.git
+    pkgs.btar
+  ];
+
+  pyproject = true;
+
+  build-system = with pkgs.python3Packages; [ setuptools-scm ];
+
+  pythonImportsCheck = [
+    "opp_env.database"
+  ];
+
+  doCheck = true;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711389443,
+        "narHash": "sha256-D3oOWNq83FBjVP4Mqd4GW/1odb28Q9XLt3AxEoXDQg8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e1eecbd8de194bbd3c3ad915608a0e7fbcadfe11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "opp_env";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }:
+  let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in {
+
+    packages.${system} = rec {
+      opp_env = pkgs.callPackage ./default.nix {};
+      default = opp_env;
+    };
+
+  };
+}


### PR DESCRIPTION
This PR adds a flake with a Nix packaged version of `opp_env`.

To do so, I had to patch `opp_env` in some ways to align the project with the Nix workflow.
The patches are in the `nix` directory in the source tree.

Changes from the included patches:
1. We need to reset the permissions of the `templates` when running `opp_env init`, because when installed via nix, they are copied from the Nix store and therefore are read-only.
2. I removed the pip dependency as well as the upgrade subcommand, as they are not compatible with an installation via Nix.